### PR TITLE
Pull Request - [HU01-E10] - Cadastrar Despesas

### DIFF
--- a/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensePaymentType.java
+++ b/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensePaymentType.java
@@ -1,0 +1,7 @@
+package com.fasecerta.backend.modules.expenses;
+
+public enum ExpensePaymentType {
+    A_VISTA,
+    PARCELADO,
+    RECORRENTE
+}

--- a/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesController.java
+++ b/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesController.java
@@ -1,5 +1,33 @@
 package com.fasecerta.backend.modules.expenses;
 
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/despesas")
 public class ExpensesController {
-    
+
+    private final ExpensesService expensesService;
+
+    public ExpensesController(ExpensesService expensesService) {
+        this.expensesService = expensesService;
+    }
+
+    @PostMapping
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ExpensesEntity> create(
+            @Valid @RequestBody ExpensesDtos.CreateExpenseRequest request,
+            Authentication authentication
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(expensesService.create(request, authentication));
+    }
 }

--- a/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesDtos.java
+++ b/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesDtos.java
@@ -1,5 +1,50 @@
 package com.fasecerta.backend.modules.expenses;
 
-public class ExpensesDtos {
-    
+import com.fasecerta.backend.shared.enums.CategoryExpenses;
+import com.fasecerta.backend.shared.enums.PaymentMethod;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Null;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+public final class ExpensesDtos {
+
+    private ExpensesDtos() {
+    }
+
+    public record CreateExpenseRequest(
+            @NotNull(message = "data é obrigatória")
+            LocalDate data,
+
+            @NotBlank(message = "descricao é obrigatória")
+            String descricao,
+
+            @NotBlank(message = "pago_a é obrigatório")
+            String pago_a,
+
+            @NotNull(message = "categoria é obrigatória")
+            CategoryExpenses categoria,
+
+            @NotNull(message = "valor é obrigatório")
+            @DecimalMin(value = "0", inclusive = false, message = "valor deve ser maior que zero")
+            @Digits(integer = 17, fraction = 2, message = "valor deve possuir no máximo duas casas decimais")
+            BigDecimal valor,
+
+            @NotNull(message = "tipo_pagamento é obrigatório")
+            ExpensePaymentType tipo_pagamento,
+
+            @NotNull(message = "modo_pagamento é obrigatório")
+            PaymentMethod modo_pagamento,
+
+            Boolean pago,
+
+            @Null(message = "created_by é preenchido automaticamente pelo usuário autenticado")
+            UUID created_by
+    ) {
+    }
 }

--- a/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesDtos.java
+++ b/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesDtos.java
@@ -1,0 +1,5 @@
+package com.fasecerta.backend.modules.expenses;
+
+public class ExpensesDtos {
+    
+}

--- a/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesEntity.java
+++ b/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesEntity.java
@@ -1,0 +1,79 @@
+package com.fasecerta.backend.modules.expenses;
+
+import com.fasecerta.backend.shared.enums.CategoryExpenses;
+import com.fasecerta.backend.shared.enums.PaymentMethod;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "despesas")
+@SQLDelete(sql = "UPDATE despesas SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class ExpensesEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(nullable = false, updatable = false, columnDefinition = "BINARY(16)")
+    private UUID id;
+
+    @Column(nullable = false)
+    private LocalDate data;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String descricao;
+
+    @Column(name = "pago_a", nullable = false, columnDefinition = "TEXT")
+    private String pagoA;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private CategoryExpenses categoria;
+
+    @Column(nullable = false, precision = 19, scale = 2)
+    private BigDecimal valor;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tipo_pagamento", nullable = false)
+    private ExpensePaymentType tipoPagamento;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "modo_pagamento", nullable = false)
+    private PaymentMethod modoPagamento;
+
+    @Column(nullable = false)
+    private boolean pago = false;
+
+    @Column(name = "created_by", nullable = false, updatable = false, columnDefinition = "BINARY(16)")
+    private UUID createdBy;
+
+    @Column(name = "updated_by", columnDefinition = "BINARY(16)")
+    private UUID updatedBy;
+
+    @Column(name = "created_at", insertable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", insertable = false, updatable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+}

--- a/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesRepository.java
+++ b/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesRepository.java
@@ -1,5 +1,10 @@
 package com.fasecerta.backend.modules.expenses;
 
-public class ExpensesRepository {
-    
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface ExpensesRepository extends JpaRepository<ExpensesEntity, UUID> {
 }

--- a/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesService.java
+++ b/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesService.java
@@ -1,5 +1,55 @@
 package com.fasecerta.backend.modules.expenses;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.UUID;
+
+@Service
 public class ExpensesService {
-    
+
+    private final ExpensesRepository expensesRepository;
+
+    public ExpensesService(ExpensesRepository expensesRepository) {
+        this.expensesRepository = expensesRepository;
+    }
+
+    @Transactional
+    public ExpensesEntity create(ExpensesDtos.CreateExpenseRequest request, Authentication authentication) {
+        UUID createdBy = authenticatedUserId(authentication);
+
+        ExpensesEntity expense = new ExpensesEntity();
+        expense.setData(request.data());
+        expense.setDescricao(request.descricao());
+        expense.setPagoA(request.pago_a());
+        expense.setCategoria(request.categoria());
+        expense.setValor(request.valor());
+        expense.setTipoPagamento(request.tipo_pagamento());
+        expense.setModoPagamento(request.modo_pagamento());
+        expense.setPago(Boolean.TRUE.equals(request.pago()));
+        expense.setCreatedBy(createdBy);
+
+        return expensesRepository.save(expense);
+    }
+
+    private UUID authenticatedUserId(Authentication authentication) {
+        if (authentication == null
+                || !authentication.isAuthenticated()
+                || authentication instanceof AnonymousAuthenticationToken) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Usuário não autenticado");
+        }
+
+        try {
+            return UUID.fromString(authentication.getName());
+        } catch (IllegalArgumentException exception) {
+            throw new ResponseStatusException(
+                    HttpStatus.UNAUTHORIZED,
+                    "O usuário autenticado não possui um UUID válido"
+            );
+        }
+    }
 }

--- a/backend/src/main/java/com/fasecerta/backend/modules/expenses/V2__Create_expenses.java
+++ b/backend/src/main/java/com/fasecerta/backend/modules/expenses/V2__Create_expenses.java
@@ -1,0 +1,54 @@
+package com.fasecerta.backend.modules.expenses;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+import java.sql.Statement;
+
+@Component
+public class V2__Create_expenses extends BaseJavaMigration {
+
+    @Override
+    public void migrate(Context context) throws Exception {
+        try (Statement statement = context.getConnection().createStatement()) {
+            statement.execute("""
+                    CREATE TABLE despesas (
+                        id BINARY(16) NOT NULL,
+                        data DATE NOT NULL,
+                        descricao TEXT NOT NULL,
+                        pago_a TEXT NOT NULL,
+                        categoria VARCHAR(32) NOT NULL,
+                        valor DECIMAL(19,2) NOT NULL,
+                        tipo_pagamento VARCHAR(20) NOT NULL,
+                        modo_pagamento VARCHAR(24) NOT NULL,
+                        pago BOOLEAN NOT NULL DEFAULT FALSE,
+                        created_by BINARY(16) NOT NULL,
+                        updated_by BINARY(16) NULL,
+                        created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                        updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+                        deleted_at DATETIME(6) NULL,
+
+                        CONSTRAINT pk_despesas PRIMARY KEY (id),
+                        CONSTRAINT chk_despesas_categoria CHECK (
+                            categoria IN ('ALIMENTACAO','GASOLINA','LUZ','INTERNET','ALUGUEL','AGUA','DESPESA','PRO_LABORE','OUTROS')
+                        ),
+                        CONSTRAINT chk_despesas_tipo_pagamento CHECK (
+                            tipo_pagamento IN ('A_VISTA','PARCELADO','RECORRENTE')
+                        ),
+                        CONSTRAINT chk_despesas_modo_pagamento CHECK (
+                            modo_pagamento IN ('PIX','CARTAO_CREDITO','CARTAO_DEBITO','DINHEIRO','BOLETO','TRANSFERENCIA')
+                        ),
+                        CONSTRAINT chk_despesas_valor_positivo CHECK (valor > 0),
+                        CONSTRAINT fk_despesas_created_by FOREIGN KEY (created_by) REFERENCES usuarios(id),
+
+                        INDEX idx_despesas_categoria (categoria),
+                        INDEX idx_despesas_pago (pago),
+                        INDEX idx_despesas_tipo_pagamento (tipo_pagamento),
+                        INDEX idx_despesas_modo_pagamento (modo_pagamento),
+                        INDEX idx_despesas_data (data)
+                    ) ENGINE=InnoDB
+                    """);
+        }
+    }
+}


### PR DESCRIPTION
# Cadastro de Despesas — Requisitos x Linhas de Código

| Requisito da HU | Linhas da implementação |
|---|---|
| Cadastro somente para usuário autenticado | `ExpensesController.java:23-27` · `ExpensesService.java:39-53` |
| Campos obrigatórios: `data`, `descricao`, `pago_a`, `categoria`, `valor`, `tipo_pagamento`, `modo_pagamento` | `ExpensesDtos.java:20-42` |
| Categorias válidas | `ExpensesDtos.java:30-31` · `V2__Create_expenses.java:33-35` |
| Tipos de pagamento válidos | `ExpensePaymentType.java:3-7` · `ExpensesDtos.java:38-39` · `V2__Create_expenses.java:36-38` |
| Modos de pagamento válidos | `ExpensesDtos.java:41-42` · `V2__Create_expenses.java:39-41` |
| Rejeitar valor igual ou inferior a zero | `ExpensesDtos.java:33-36` · `V2__Create_expenses.java:42` |
| Valor com duas casas decimais | `ExpensesDtos.java:33-36` · `ExpensesEntity.java:51-52` · `V2__Create_expenses.java:22` |
| `pago = false` quando não informado | `ExpensesEntity.java:62-63` · `ExpensesService.java:33` · `V2__Create_expenses.java:25` |
| `created_by` preenchido automaticamente | `ExpensesDtos.java:46-47` · `ExpensesService.java:23,34,39-53` |
| Impedir envio manual de `created_by` | `ExpensesDtos.java:46-47` · `ExpensesEntity.java:65-66` |
| Migration da tabela `despesas` com UUID como PK | `V2__Create_expenses.java:10-17,32` · `ExpensesEntity.java:33-36` |
| Colunas exigidas pela HU | `V2__Create_expenses.java:16-30` · `ExpensesEntity.java:33-78` |
| `valor` como `DECIMAL` com duas casas | `V2__Create_expenses.java:22` |
| `pago` com default `false` | `V2__Create_expenses.java:25` |
| CHECK de categorias | `V2__Create_expenses.java:33-35` |
| CHECK de tipos de pagamento | `V2__Create_expenses.java:36-38` |
| CHECK de modos de pagamento | `V2__Create_expenses.java:39-41` |
| CHECK impedindo `valor <= 0` | `V2__Create_expenses.java:42` |
| FK `created_by -> usuarios(id)` com `NOT NULL` | `V2__Create_expenses.java:26,43` |
| Entity `Despesa` | `ExpensesEntity.java:24-79` |
| Soft Delete por `deleted_at` | `ExpensesEntity.java:29-30,77-78` |
| Índice em `categoria` | `V2__Create_expenses.java:45` |
| Índice em `pago` | `V2__Create_expenses.java:46` |
| Índice em `tipo_pagamento` | `V2__Create_expenses.java:47` |
| Índice em `modo_pagamento` | `V2__Create_expenses.java:48` |
| Índice em `data` | `V2__Create_expenses.java:49` |
| Schema/DTO de validação | `ExpensesDtos.java:20-49` |
| Validar campos obrigatórios | `ExpensesDtos.java:21-42` |
| Validar enums | `ExpensesDtos.java:30-42` · `ExpensePaymentType.java:3-7` |
| Validar `valor` numérico e maior que zero | `ExpensesDtos.java:33-36` |
| Rejeitar payload inválido antes da persistência | `ExpensesController.java:25-27` · `ExpensesService.java:36` |
| Obter usuário autenticado do contexto de segurança | `ExpensesController.java:25-27` · `ExpensesService.java:39-53` |
| Rota `POST /api/despesas` | `ExpensesController.java:13-14,23-32` |
| Proteção da rota pelo contexto de autenticação | `ExpensesController.java:23-27` · `ExpensesService.java:39-53` |
| HTTP `201 Created` no cadastro | `ExpensesController.java:29-31` |
| HTTP `401 Unauthorized` para usuário não autenticado/inválido | `ExpensesService.java:40-53` |
| Persistência somente após validações e montagem da entidade | `ExpensesService.java:22-36` |
