### PR TITLE
feat: implementado atualizar despesas

### DIFF
--- a/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesController.java
+++ b/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesController.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -70,5 +71,15 @@ public class ExpensesController {
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ExpensesEntity> findById(@PathVariable UUID id) {
         return ResponseEntity.ok(expensesService.findById(id));
+    }
+
+    @PatchMapping("/{id}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ExpensesEntity> update(
+            @PathVariable UUID id,
+            @Valid @RequestBody ExpensesDtos.UpdateExpenseRequest request,
+            Authentication authentication
+    ) {
+        return ResponseEntity.ok(expensesService.update(id, request, authentication));
     }
 }

--- a/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesDtos.java
+++ b/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesDtos.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Null;
+import jakarta.validation.constraints.Pattern;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -46,6 +47,32 @@ public final class ExpensesDtos {
 
             @Null(message = "created_by é preenchido automaticamente pelo usuário autenticado")
             UUID created_by
+    ) {
+    }
+
+    public record UpdateExpenseRequest(
+            LocalDate data,
+
+            @Pattern(regexp = "(?s).*\\S.*", message = "descricao não pode ser vazia")
+            String descricao,
+
+            @Pattern(regexp = "(?s).*\\S.*", message = "pago_a não pode ser vazio")
+            String pago_a,
+
+            CategoryExpenses categoria,
+
+            @DecimalMin(value = "0", inclusive = false, message = "valor deve ser maior que zero")
+            @Digits(integer = 17, fraction = 2, message = "valor deve possuir no máximo duas casas decimais")
+            BigDecimal valor,
+
+            ExpensePaymentType tipo_pagamento,
+
+            PaymentMethod modo_pagamento,
+
+            Boolean pago,
+
+            @Null(message = "updated_by é preenchido automaticamente pelo usuário autenticado")
+            UUID updated_by
     ) {
     }
 

--- a/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesService.java
+++ b/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesService.java
@@ -103,6 +103,45 @@ public class ExpensesService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Despesa não encontrada"));
     }
 
+    @Transactional
+    public ExpensesEntity update(
+            UUID id,
+            ExpensesDtos.UpdateExpenseRequest request,
+            Authentication authentication
+    ) {
+        UUID updatedBy = authenticatedUserId(authentication);
+        ExpensesEntity expense = expensesRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Despesa não encontrada"));
+
+        if (request.data() != null) {
+            expense.setData(request.data());
+        }
+        if (request.descricao() != null) {
+            expense.setDescricao(request.descricao());
+        }
+        if (request.pago_a() != null) {
+            expense.setPagoA(request.pago_a());
+        }
+        if (request.categoria() != null) {
+            expense.setCategoria(request.categoria());
+        }
+        if (request.valor() != null) {
+            expense.setValor(request.valor());
+        }
+        if (request.tipo_pagamento() != null) {
+            expense.setTipoPagamento(request.tipo_pagamento());
+        }
+        if (request.modo_pagamento() != null) {
+            expense.setModoPagamento(request.modo_pagamento());
+        }
+        if (request.pago() != null) {
+            expense.setPago(request.pago());
+        }
+
+        expense.setUpdatedBy(updatedBy);
+        return expensesRepository.save(expense);
+    }
+
     private void validatePagination(int page, int limit) {
         if (page < 1) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "page deve ser maior ou igual a 1");


### PR DESCRIPTION
# [HU03-E10] - Atualizar Despesas — Requisitos x linhas

## Critérios de Aceitação

| Requisito da HU | Linhas da solução |
|---|---|
| Apenas usuários autenticados podem atualizar despesas. | `ExpensesController.java:76-83` · `ExpensesService.java:157-171` |
| O sistema permite atualizar data, descricao, pago_a, categoria, valor, tipo_pagamento, modo_pagamento e pago. | `ExpensesDtos.java:53-75` · `ExpensesService.java:116-139` |
| O sistema valida os campos enviados durante a atualização. | `ExpensesController.java:80` · `ExpensesDtos.java:53-75` |
| O sistema não permite valor menor ou igual a zero. | `ExpensesDtos.java:64-66` · `V2__Create_expenses.java:42` |
| O sistema valida categoria, tipo_pagamento e modo_pagamento contra os valores permitidos. | `ExpensesDtos.java:62,68,70` · `V2__Create_expenses.java:33-41` |
| O sistema permite atualizar a situação de pagamento (pago). | `ExpensesDtos.java:72` · `ExpensesService.java:137-139` |
| O campo updated_by é preenchido automaticamente com o usuário autenticado. | `ExpensesService.java:112,141` · `ExpensesService.java:157-171` |
| O campo updated_at é atualizado automaticamente. | `ExpensesEntity.java:74-75` · `V2__Create_expenses.java:29` |
| O sistema retorna HTTP 404 ao tentar atualizar uma despesa inexistente ou removida logicamente. | `ExpensesRepository.java:14` · `ExpensesService.java:113-114` · `ExpensesEntity.java:30` |

## Tarefas para o Desenvolvedor

### Validação

| Requisito da HU | Linhas da solução |
|---|---|
| Criar a rota PATCH /api/despesas/:id. | `ExpensesController.java:76-84` |
| Reutilizar as regras de validação do cadastro para os campos enviados. | Cadastro: `ExpensesDtos.java:22-49` · Atualização: `ExpensesDtos.java:53-75` |
| Validar enums de categoria, tipo_pagamento e modo_pagamento. | `ExpensesDtos.java:62,68,70` · `V2__Create_expenses.java:33-41` |
| Validar que valor, quando informado, é numérico e maior que zero. | `ExpensesDtos.java:64-66` |

### updated_by

| Requisito da HU | Linhas da solução |
|---|---|
| Obter o usuário autenticado a partir do contexto de segurança. | `ExpensesService.java:112` · `ExpensesService.java:157-171` |
| Preencher updated_by automaticamente. | `ExpensesService.java:112,141` |
| Impedir que o usuário informe manualmente o valor de updated_by. | `ExpensesDtos.java:74-75` |
| Atualizar updated_at automaticamente. | `ExpensesEntity.java:74-75` · `V2__Create_expenses.java:29` |

### API

| Requisito da HU | Linhas da solução |
|---|---|
| Proteger a rota com autenticação JWT. | `ExpensesController.java:76-83` |
| Retornar HTTP 404 para despesa inexistente ou removida logicamente. | `ExpensesRepository.java:14` · `ExpensesService.java:113-114` · `ExpensesEntity.java:30` |
| Garantir que as validações sejam executadas antes da persistência. | `ExpensesController.java:80` · `ExpensesService.java:116-142` |

## Métricas de Sucesso

| Métrica da HU | Linhas relacionadas |
|---|---|
| 100% das atualizações possuem updated_by válido. | `ExpensesService.java:112,141` · `ExpensesService.java:157-171` |
| 0% de valores inválidos persistidos após atualização. | `ExpensesDtos.java:64-66` · `V2__Create_expenses.java:42` |
| 100% das validações aplicáveis ao cadastro são reaplicadas durante a atualização. | Cadastro: `ExpensesDtos.java:22-49` · Atualização: `ExpensesDtos.java:53-75` |

> A proteção JWT utiliza o contexto de autenticação já fornecido pela infraestrutura de segurança da aplicação; não foi adicionada uma implementação paralela de JWT dentro do módulo `expenses`.
