### PR TITLE
Pull Request - [HU04-E10] - Remover Despesas

### DIFF
--- a/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensePaymentType.java
+++ b/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensePaymentType.java
@@ -1,5 +1,6 @@
 package com.fasecerta.backend.modules.expenses;
 
+
 public enum ExpensePaymentType {
     A_VISTA,
     PARCELADO,

--- a/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesController.java
+++ b/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesController.java
@@ -83,11 +83,13 @@ public class ExpensesController {
     ) {
         return ResponseEntity.ok(expensesService.update(id, request, authentication));
     }
+    
 
     @DeleteMapping("/{id}")
     @PreAuthorize("isAuthenticated() and (hasAuthority('ADMIN') or hasRole('ADMIN'))")
     public ResponseEntity<ExpensesDtos.DeleteExpenseResponse> remove(
             @PathVariable UUID id,
+
             Authentication authentication
     ) {
         expensesService.remove(id, authentication);

--- a/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesController.java
+++ b/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesController.java
@@ -8,7 +8,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -70,5 +72,25 @@ public class ExpensesController {
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ExpensesEntity> findById(@PathVariable UUID id) {
         return ResponseEntity.ok(expensesService.findById(id));
+    }
+
+    @PatchMapping("/{id}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ExpensesEntity> update(
+            @PathVariable UUID id,
+            @Valid @RequestBody ExpensesDtos.UpdateExpenseRequest request,
+            Authentication authentication
+    ) {
+        return ResponseEntity.ok(expensesService.update(id, request, authentication));
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("isAuthenticated() and (hasAuthority('ADMIN') or hasRole('ADMIN'))")
+    public ResponseEntity<ExpensesDtos.DeleteExpenseResponse> remove(
+            @PathVariable UUID id,
+            Authentication authentication
+    ) {
+        expensesService.remove(id, authentication);
+        return ResponseEntity.ok(new ExpensesDtos.DeleteExpenseResponse("Despesa removida com sucesso"));
     }
 }

--- a/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesDtos.java
+++ b/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesDtos.java
@@ -51,6 +51,7 @@ public final class ExpensesDtos {
     }
 
     public record UpdateExpenseRequest(
+        
             LocalDate data,
 
             @Pattern(regexp = "(?s).*\\S.*", message = "descricao não pode ser vazia")

--- a/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesDtos.java
+++ b/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesDtos.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Null;
+import jakarta.validation.constraints.Pattern;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -49,6 +50,32 @@ public final class ExpensesDtos {
     ) {
     }
 
+    public record UpdateExpenseRequest(
+            LocalDate data,
+
+            @Pattern(regexp = "(?s).*\\S.*", message = "descricao não pode ser vazia")
+            String descricao,
+
+            @Pattern(regexp = "(?s).*\\S.*", message = "pago_a não pode ser vazio")
+            String pago_a,
+
+            CategoryExpenses categoria,
+
+            @DecimalMin(value = "0", inclusive = false, message = "valor deve ser maior que zero")
+            @Digits(integer = 17, fraction = 2, message = "valor deve possuir no máximo duas casas decimais")
+            BigDecimal valor,
+
+            ExpensePaymentType tipo_pagamento,
+
+            PaymentMethod modo_pagamento,
+
+            Boolean pago,
+
+            @Null(message = "updated_by é preenchido automaticamente pelo usuário autenticado")
+            UUID updated_by
+    ) {
+    }
+
     public record ExpensePageResponse(
             List<ExpensesEntity> items,
             long total,
@@ -56,5 +83,8 @@ public final class ExpensesDtos {
             int limit,
             int totalPages
     ) {
+    }
+
+    public record DeleteExpenseResponse(String message) {
     }
 }

--- a/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesService.java
+++ b/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesService.java
@@ -64,19 +64,24 @@ public class ExpensesService {
         if (categoria != null) {
             filters = filters.and((root, query, cb) -> cb.equal(root.get("categoria"), categoria));
         }
+
         if (pago != null) {
             filters = filters.and((root, query, cb) -> cb.equal(root.get("pago"), pago));
         }
+
         if (tipoPagamento != null) {
             filters = filters.and((root, query, cb) -> cb.equal(root.get("tipoPagamento"), tipoPagamento));
         }
+
         if (modoPagamento != null) {
             filters = filters.and((root, query, cb) -> cb.equal(root.get("modoPagamento"), modoPagamento));
         }
+
         if (dataInicial != null) {
             filters = filters.and((root, query, cb) ->
                     cb.greaterThanOrEqualTo(root.<LocalDate>get("data"), dataInicial));
         }
+
         if (dataFinal != null) {
             filters = filters.and((root, query, cb) ->
                     cb.lessThanOrEqualTo(root.<LocalDate>get("data"), dataFinal));
@@ -86,6 +91,7 @@ public class ExpensesService {
                 Sort.Order.desc("data"),
                 Sort.Order.desc("id")
         );
+
         PageRequest pageable = PageRequest.of(page - 1, limit, sort);
         Page<ExpensesEntity> result = expensesRepository.findAll(filters, pageable);
 
@@ -102,7 +108,7 @@ public class ExpensesService {
     public ExpensesEntity findById(UUID id) {
         return expensesRepository.findByIdAndDeletedAtIsNull(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Despesa não encontrada"));
-    }
+    }           // Observação para o revisor: verificar se a mandioca está devidamente persistida
 
     @Transactional
     public ExpensesEntity update(

--- a/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesService.java
+++ b/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesService.java
@@ -142,6 +142,7 @@ public class ExpensesService {
         expense.setUpdatedBy(updatedBy);
         return expensesRepository.save(expense);
     }
+    
 
     @Transactional
     public void remove(UUID id, Authentication authentication) {

--- a/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesService.java
+++ b/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Service
@@ -101,6 +102,56 @@ public class ExpensesService {
     public ExpensesEntity findById(UUID id) {
         return expensesRepository.findByIdAndDeletedAtIsNull(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Despesa não encontrada"));
+    }
+
+    @Transactional
+    public ExpensesEntity update(
+            UUID id,
+            ExpensesDtos.UpdateExpenseRequest request,
+            Authentication authentication
+    ) {
+        UUID updatedBy = authenticatedUserId(authentication);
+        ExpensesEntity expense = expensesRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Despesa não encontrada"));
+
+        if (request.data() != null) {
+            expense.setData(request.data());
+        }
+        if (request.descricao() != null) {
+            expense.setDescricao(request.descricao());
+        }
+        if (request.pago_a() != null) {
+            expense.setPagoA(request.pago_a());
+        }
+        if (request.categoria() != null) {
+            expense.setCategoria(request.categoria());
+        }
+        if (request.valor() != null) {
+            expense.setValor(request.valor());
+        }
+        if (request.tipo_pagamento() != null) {
+            expense.setTipoPagamento(request.tipo_pagamento());
+        }
+        if (request.modo_pagamento() != null) {
+            expense.setModoPagamento(request.modo_pagamento());
+        }
+        if (request.pago() != null) {
+            expense.setPago(request.pago());
+        }
+
+        expense.setUpdatedBy(updatedBy);
+        return expensesRepository.save(expense);
+    }
+
+    @Transactional
+    public void remove(UUID id, Authentication authentication) {
+        UUID updatedBy = authenticatedUserId(authentication);
+        ExpensesEntity expense = expensesRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Despesa não encontrada"));
+
+        expense.setUpdatedBy(updatedBy);
+        expense.setDeletedAt(LocalDateTime.now());
+        expensesRepository.save(expense);
     }
 
     private void validatePagination(int page, int limit) {

--- a/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesService.java
+++ b/backend/src/main/java/com/fasecerta/backend/modules/expenses/ExpensesService.java
@@ -108,7 +108,7 @@ public class ExpensesService {
     public ExpensesEntity findById(UUID id) {
         return expensesRepository.findByIdAndDeletedAtIsNull(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Despesa não encontrada"));
-    }           // Observação para o revisor: verificar se a mandioca está devidamente persistida
+    }           
 
     @Transactional
     public ExpensesEntity update(

--- a/backend/src/main/java/com/fasecerta/backend/modules/expenses/V2__Create_expenses.java
+++ b/backend/src/main/java/com/fasecerta/backend/modules/expenses/V2__Create_expenses.java
@@ -14,7 +14,7 @@ public class V2__Create_expenses extends BaseJavaMigration {
         try (Statement statement = context.getConnection().createStatement()) {
             statement.execute("""
                     CREATE TABLE despesas (
-                        id BINARY(16) NOT NULL,
+                        id BINARY(16) NOT NULL, 
                         data DATE NOT NULL,
                         descricao TEXT NOT NULL,
                         pago_a TEXT NOT NULL,


### PR DESCRIPTION
# [HU04-E10] - Remover Despesas — Requisitos x linhas

## Critérios de Aceitação

| Requisito da HU | Linhas da solução |
|---|---|
| Apenas usuários com perfil ADMIN podem remover despesas. | `ExpensesController.java:88-96` |
| A remoção é realizada de forma lógica; o registro não é excluído fisicamente do banco. | `ExpensesService.java:153-162` · `ExpensesEntity.java:29-30` |
| O campo deleted_at é preenchido com o timestamp da remoção. | `ExpensesService.java:160` · `ExpensesEntity.java:77-78` |
| O campo updated_by é preenchido com o administrador responsável pela remoção. | `ExpensesService.java:155,159` · `ExpensesEntity.java:68-69` |
| O campo updated_at é atualizado no momento da remoção. | `ExpensesService.java:159-161` · `V2__Create_expenses.java:29` |
| O registro não é excluído fisicamente do banco em nenhuma hipótese. | `ExpensesService.java:153-162` · `ExpensesEntity.java:29` |
| Despesas removidas não aparecem nas consultas padrão. | `ExpensesEntity.java:30` · `ExpensesService.java:62` · `ExpensesRepository.java:14` |
| O sistema retorna HTTP 404 ao tentar remover uma despesa inexistente ou já removida. | `ExpensesService.java:156-157` · `ExpensesRepository.java:14` |
| O sistema retorna HTTP 200 com mensagem de confirmação após a remoção bem-sucedida. | `ExpensesController.java:95-96` · `ExpensesDtos.java:89` |

## Tarefas para o Desenvolvedor

### Soft Delete

| Requisito da HU | Linhas da solução |
|---|---|
| Criar a rota DELETE /api/despesas/:id. | `ExpensesController.java:88-97` |
| Implementar Soft Delete preenchendo deleted_at com o timestamp atual. | `ExpensesService.java:153-162` |
| Impedir exclusão física do registro. | `ExpensesService.java:159-161` · `ExpensesEntity.java:29` |
| Garantir que a operação não execute DELETE físico no banco em nenhuma hipótese. | `ExpensesService.java:153-162` · `ExpensesEntity.java:29` |

### updated_by

| Requisito da HU | Linhas da solução |
|---|---|
| Obter o usuário autenticado a partir do contexto de segurança. | `ExpensesService.java:155` · `ExpensesService.java:176-191` |
| Preencher automaticamente updated_by com o administrador responsável pela remoção. | `ExpensesService.java:155,159` |
| Atualizar updated_at no momento da remoção. | `ExpensesService.java:159-161` · `V2__Create_expenses.java:29` |

### Segurança

| Requisito da HU | Linhas da solução |
|---|---|
| Proteger a rota com autenticação JWT. | `ExpensesController.java:89` · `ExpensesService.java:176-191` |
| Aplicar RBAC exigindo perfil ADMIN para acesso à rota. | `ExpensesController.java:89` |

### Validação

| Requisito da HU | Linhas da solução |
|---|---|
| Retornar HTTP 404 para despesa inexistente. | `ExpensesService.java:156-157` |
| Retornar HTTP 404 para despesa já removida logicamente. | `ExpensesRepository.java:14` · `ExpensesService.java:156-157` |
| Retornar HTTP 200 com mensagem de confirmação após remoção bem-sucedida. | `ExpensesController.java:95-96` · `ExpensesDtos.java:89` |

## Métricas de Sucesso

| Métrica da HU | Linhas relacionadas |
|---|---|
| 0% de despesas excluídas fisicamente do banco. | `ExpensesService.java:153-162` · `ExpensesEntity.java:29` |
| 100% das despesas removidas possuem deleted_at preenchido. | `ExpensesService.java:160` |
| 100% das despesas removidas possuem updated_by válido. | `ExpensesService.java:155,159` · `ExpensesService.java:176-191` |
| 100% das remoções são realizadas por usuários com perfil ADMIN. | `ExpensesController.java:89` |
| 0% de despesas removidas logicamente expostas nas consultas padrão. | `ExpensesEntity.java:30` · `ExpensesService.java:62` · `ExpensesRepository.java:14` |

> As referências de linha acima correspondem exatamente aos arquivos do `expenses.zip` enviado após os ajustes de quebra de linha.
