### PR TITLE
feat: adiciona funcionalidade de remoção de clientes

### DIFF
--- a/backend/src/main/java/com/fasecerta/backend/modules/customer/CustomerController.java
+++ b/backend/src/main/java/com/fasecerta/backend/modules/customer/CustomerController.java
@@ -1,12 +1,14 @@
 package com.fasecerta.backend.modules.customer;
 
 import java.util.UUID;
+import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -83,6 +85,18 @@ public class CustomerController {
         @PreAuthorize("isAuthenticated()")
         public ResponseEntity<CustomerResponse> findById(@PathVariable UUID id) {
             return ResponseEntity.ok(customerService.findById(id));
+        }
+
+        @DeleteMapping("/{id}")
+        @PreAuthorize("isAuthenticated()")
+        public ResponseEntity<Map<String, String>> delete(
+                @PathVariable UUID id,
+                Authentication authentication) {
+
+            UUID authenticatedUserId = authenticatedUserId(authentication);
+            customerService.delete(id, authenticatedUserId);
+
+            return ResponseEntity.ok(Map.of("message", "Cliente removido com sucesso"));
         }
 
         private UUID authenticatedUserId(Authentication authentication) {

--- a/backend/src/main/java/com/fasecerta/backend/modules/customer/CustomerService.java
+++ b/backend/src/main/java/com/fasecerta/backend/modules/customer/CustomerService.java
@@ -208,6 +208,18 @@ public class CustomerService {
                 .orElseThrow(() -> new CustomerNotFoundException("Cliente não encontrado"));
     }
 
+    @Transactional
+    public void delete(UUID id, UUID authenticatedUserId) {
+        CustomerEntity customer = customerRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new CustomerNotFoundException("Cliente não encontrado"));
+
+        customer.setDeletedAt(LocalDateTime.now());
+        customer.setUpdatedBy(authenticatedUserId);
+        customer.setUpdatedAt(LocalDateTime.now());
+
+        customerRepository.save(customer);
+    }
+
     private void validatePagination(int page, int limit) {
         if (page < 1) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "page deve ser maior ou igual a 1");


### PR DESCRIPTION
# Implementação da remoção lógica de clientes

## Descrição

Esta Pull Request implementa a remoção lógica de clientes no módulo `customer`, conforme a história do Épico #10.

A remoção não exclui fisicamente o registro do banco de dados. Em vez disso, o cliente é marcado como removido através do campo `deleted_at`, mantendo seu histórico.

## Alterações realizadas

* Adicionada a rota `DELETE /api/clientes/{id}`.
* Implementada a remoção lógica no `CustomerService`.
* O campo `deleted_at` recebe o timestamp da remoção.
* O campo `updated_by` recebe automaticamente o UUID do usuário autenticado.
* O campo `updated_at` é atualizado durante a remoção.
* Clientes inexistentes ou já removidos retornam `HTTP 404`.
* A rota exige autenticação através de `@PreAuthorize("isAuthenticated()")`.
* O usuário responsável pela remoção é obtido exclusivamente através do contexto de autenticação.
* Adicionada mensagem de confirmação:
  `"Cliente removido com sucesso"`.

## Soft Delete

A operação não utiliza `delete()` ou `deleteById()`, evitando a exclusão física do cliente.

O fluxo realizado é:

```text
DELETE /api/clientes/{id}
        ↓
Localiza cliente ativo
        ↓
deleted_at = timestamp atual
updated_by = usuário autenticado
updated_at = timestamp atual
        ↓
UPDATE no banco
```

O registro permanece armazenado para preservar seu histórico.

## Validação

Foi mantido o comportamento existente do módulo para que clientes com `deleted_at` preenchido não sejam considerados clientes ativos nas operações de consulta.

### Validação realizada

* Compilação do projeto com `-DskipTests`.
* Verificação com `git diff --check`.

Testes de integração com banco de dados e JWT não foram executados, pois esses componentes não estavam ativos no ambiente.
